### PR TITLE
fix: do not force undefined on defaultIntagrations

### DIFF
--- a/index.js
+++ b/index.js
@@ -72,8 +72,7 @@ module.exports = fp(
             environment,
             release,
             autoSessionTracking,
-            defaultIntegrations:
-                defaultIntegrations === false ? defaultIntegrations : undefined,
+            defaultIntegrations,
             integrations,
             ...sentryOptions,
         });


### PR DESCRIPTION
Forcing `defaultIntegrations` to `undefined` was causing more harm than good, especially if you wanted to activate a custom list of integrations using that option.