### PR TITLE
Stop overriding Sentry default options

### DIFF
--- a/MIGRATION_GUIDE.md
+++ b/MIGRATION_GUIDE.md
@@ -1,0 +1,30 @@
+# Migrating from v1 to v2
+
+## Config options
+
+We  don't override any of the Sentry SDK options during the plugin initialization.
+
+### V1
+
+```js
+const fastify = require('fastify')();
+
+fastify.register(require('@immobiliarelabs/fastify-sentry'), {
+    dsn: ...,
+});
+```
+
+### V2
+
+> The equivalent of the default config in version 1 would be
+
+```js
+const fastify = require('fastify')();
+
+fastify.register(require('@immobiliarelabs/fastify-sentry'), {
+    dsn: ...,
+    environment: 'Local',
+    defaultIntegrations: false,
+    autoSessionTracking: false,
+});
+```

--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ This plugin standardize options and payload format then registers a default erro
 <!-- toc -->
 
 - [Installation](#installation)
+- [Migrating from version 1](#migrating-from-version-1)
 - [Usage](#usage)
   * [Customization](#customization)
     + [overriding the allowed status codes](#overriding-the-allowed-status-codes)
@@ -53,6 +54,10 @@ $ yarn add @immobiliarelabs/fastify-sentry
 # latest development version
 $ yarn @immobiliarelabs/fastify-sentry@next
 ```
+
+## Migrating from version 1
+
+Please check this [migration guide](./MIGRATION_GUIDE.md) if you are migrating from the version 1 of the plugin.
 
 ## Usage
 

--- a/index.js
+++ b/index.js
@@ -55,29 +55,17 @@ module.exports = fp(
     function (
         fastify,
         {
-            dsn,
-            environment = 'Local',
+            environment,
             release,
-            autoSessionTracking = false,
-            defaultIntegrations = false,
-            integrations,
             allowedStatusCodes = defaultAllowedStatusCodes,
             onErrorFactory = defaultErrorFactory,
             ...sentryOptions
         },
         next
     ) {
-        Sentry.init({
-            dsn,
-            environment,
-            release,
-            autoSessionTracking,
-            defaultIntegrations,
-            integrations,
-            ...sentryOptions,
-        });
-
-        if (!dsn) {
+        sentryOptions = sentryOptions || {};
+        Sentry.init(sentryOptions);
+        if (!sentryOptions.dsn) {
             fastify.log.error(
                 'No dsn was provided, skipping Sentry configuration.'
             );
@@ -97,7 +85,6 @@ module.exports = fp(
         const onError = onErrorFactory({
             environment,
             allowedStatusCodes,
-            fastify,
         });
         if (typeof onError !== 'function') {
             return next(new Error('onError handler must be a function'));


### PR DESCRIPTION
In this PR I am removing the plugin  behaviour  of overriding Sentry default options, which was causing more harm than good in a lot of use cases. There is also a minor fix on the documentation about the `onErrorFactory`.

It is a breaking change.

Closes #22 ,closes #32 