### PR TITLE
fix: change log message when no dsn is passed

### DIFF
--- a/index.js
+++ b/index.js
@@ -66,9 +66,7 @@ module.exports = fp(
         sentryOptions = sentryOptions || {};
         Sentry.init(sentryOptions);
         if (!sentryOptions.dsn) {
-            fastify.log.error(
-                'No dsn was provided, skipping Sentry configuration.'
-            );
+            fastify.log.error('No Sentry DSN was provided.');
         }
 
         try {


### PR DESCRIPTION
The previous message was misleading because it implied that Sentry was not
being configured if no DSN was passed.
Closes #96