### PR TITLE
Support `environment` and `release` options in `Sentry.init`

### DIFF
--- a/index.js
+++ b/index.js
@@ -59,8 +59,6 @@ module.exports = fp(
     function (
         fastify,
         {
-            environment,
-            release,
             allowedStatusCodes = defaultAllowedStatusCodes,
             onErrorFactory = defaultErrorFactory,
             ...sentryOptions
@@ -75,8 +73,6 @@ module.exports = fp(
 
         try {
             validateOptions({
-                environment,
-                release,
                 allowedStatusCodes,
                 onErrorFactory,
             });
@@ -85,7 +81,6 @@ module.exports = fp(
         }
 
         const onError = onErrorFactory({
-            environment,
             allowedStatusCodes,
         });
         if (typeof onError !== 'function') {


### PR DESCRIPTION
It PR removed `environment` and `release` options from destructing statement on [L58-L59](https://github.com/immobiliare/fastify-sentry/blob/ba6c9c8210a09cbe24558229cbd8929d459cba0f/index.js#L58-L59), to make they go into the `sentryOptions` on [L62](https://github.com/immobiliare/fastify-sentry/blob/ba6c9c8210a09cbe24558229cbd8929d459cba0f/index.js#L62) which in turns goes into `Sentry.init(sentryOptions)` on [L67](https://github.com/immobiliare/fastify-sentry/blob/ba6c9c8210a09cbe24558229cbd8929d459cba0f/index.js#L67). And stop passing them to `validateOptions` function on [L73-L78](https://github.com/immobiliare/fastify-sentry/blob/ba6c9c8210a09cbe24558229cbd8929d459cba0f/index.js#L73-L78), since `validateOptions` is only interested in `allowedStatusCodes` and  `onErrorFactory`.