### PR TITLE
chore: 🤖 fix yarn install command at README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ or `yarn`
 # lastest stable version
 $ yarn add @immobiliarelabs/fastify-sentry
 # latest development version
-$ yarn @immobiliarelabs/fastify-sentry@next
+$ yarn add @immobiliarelabs/fastify-sentry@next
 ```
 
 ## Migrating from version 4


### PR DESCRIPTION
I added "add" because it was missing in the package installation command by yarn in README.md.