### PR TITLE
ci(npm): new npm feature "provenance"

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,6 +19,9 @@ jobs:
           token: ${{ secrets.GH_OWNER_TOKEN }}
           persist-credentials: false
 
+      - name: Latest NPM to use provenance
+        run: npm install -g npm@9
+
       - name: Install dependencies
         run: npm i
 

--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
     "./utils": "./lib/utils.js"
   },
   "publishConfig": {
-    "access": "public"
+    "access": "public",
+    "provenance": true
   },
   "keywords": [
     "nodejs",


### PR DESCRIPTION
FYI @dnlup @antoniomuso @JellyBellyDev This MR tests publishing to NPM using [`--provenance`](https://github.blog/2023-04-19-introducing-npm-package-provenance/)