### PR TITLE
ci: remove package lock from release

### DIFF
--- a/.releaserc.json
+++ b/.releaserc.json
@@ -11,7 +11,7 @@
     [
       "@semantic-release/git",
       {
-        "assets": ["CHANGELOG.md", "package.json", "package-lock.json"]
+        "assets": ["CHANGELOG.md", "package.json"]
       }
     ],
     "@semantic-release/github",


### PR DESCRIPTION
This removes `package-lock.json` from semantic-release git-commit 