### PR TITLE
chore(test): enable tests

### DIFF
--- a/test/plugin.test.js
+++ b/test/plugin.test.js
@@ -57,7 +57,7 @@ tap.test(
   }
 );
 
-tap.test('event with transactions disabled', { only: true }, async (t) => {
+tap.test('event with transactions disabled', async (t) => {
   const app = await setup(
     { dsn: DSN, environment: 'fastify-sentry-test' },
     async (fastify) => {


### PR DESCRIPTION
I think an `{ only: true }` slipped in with one of the latest commits. Assumably by accident. 

If the `{ only: true }` is there on purpose, please just ignore this PR.

Either way, thanks for maintaining this library. 🙏