### PR TITLE
build: release on package.json changes

### DIFF
--- a/.releaserc.json
+++ b/.releaserc.json
@@ -4,7 +4,15 @@
     { "name": "next", "channel": "next", "prerelease": true }
   ],
   "plugins": [
-    "@semantic-release/commit-analyzer",
+    [
+      "@semantic-release/commit-analyzer",
+      {
+        "preset": "angular",
+        "releaseRules": [
+          { "type": "chore", "scope": "package.json", "release": "patch" }
+        ]
+      }
+    ],
     "@semantic-release/release-notes-generator",
     "@semantic-release/changelog",
     "@semantic-release/npm",


### PR DESCRIPTION
Enable release on a chore commit on package.json so we can make a release when we update Sentry
