### PR TITLE
fix(types): fix missing dsn option

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,14 +1,14 @@
 import {
     FastifyPluginCallback,
 } from 'fastify';
-import Sentry, { Hub } from '@sentry/node';
+import Sentry, { Hub, NodeOptions } from '@sentry/node';
 
 import { shouldHandleError, errorResponse, getTransactionName, extractRequestData, extractUserData } from './utils';
 
 type FastifySentryPlugin = FastifyPluginCallback<fastifySentry.FastifySentryOptions>
 
 declare namespace fastifySentry {
-    export interface FastifySentryOptions {
+    export interface FastifySentryOptions extends NodeOptions {
         /** Set the plugin error handler */
         setErrorHandler?: boolean
         /** Called inside the error handler, it should return `true` of `false`depending on the fact we want to send the error to Sentry or not */

--- a/test/types/index.test-d.ts
+++ b/test/types/index.test-d.ts
@@ -13,3 +13,8 @@ app.get('/', async (request, reply) => {
   expectType<string>(reply.sentryEventId);
   expectType<ReturnType<Hub['startTransaction']>|null>(reply.sentryTransaction);
 })
+
+const app2 = fastify()
+app2.register(plugin, {
+  dsn: ''
+})


### PR DESCRIPTION
Extends `NodeOptions` interface from `Sentry` SDK to restore SDK options in the plugin.

Fixes #615 