### PR TITLE
feat(config): support skipping sentry init

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ This plugin standardize options and payload format then registers a default erro
     + [getTransactionName](#gettransactionname)
     + [extractRequestData](#extractrequestdata)
     + [extractUserData](#extractuserdata)
+    + [skipInit](#skipinit)
   * [utils](#utils)
     + [getTransactionName](#gettransactionname-1)
     + [extractRequestData](#extractrequestdata-1)
@@ -237,6 +238,15 @@ This function is called in the dafult error handler right after the exception is
     email: '',
 }
 ```
+
+#### skipInit
+
+> Skip the `Sentry.init` call that initializes the SDK. Useful if working in an environment that already initializes the Sentry SDK.
+
+**type**: `boolean`
+
+**default**: `false`
+
 
 ### utils
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -21,6 +21,8 @@ declare namespace fastifySentry {
         extractRequestData?: typeof extractRequestData
         /** Custom function to extract the user data from the request */
         extractUserData?: typeof extractUserData
+        /** Skip Sentry.init call (useful in serverless integrations, see https://github.com/immobiliare/fastify-sentry/issues/621) */
+        skipInit?: boolean
     }
     export const fastifySentry: FastifySentryPlugin
     export { fastifySentry as default }

--- a/index.js
+++ b/index.js
@@ -19,6 +19,7 @@ const DEFAULT_CONFIG = {
   getTransactionName,
   extractRequestData,
   extractUserData,
+  skipInit: false,
 };
 
 const fastifySentry = function (fastify, opts, next) {

--- a/lib/base.js
+++ b/lib/base.js
@@ -17,9 +17,12 @@ module.exports = function (fastify, opts) {
     getTransactionName,
     extractRequestData,
     extractUserData,
+    skipInit,
     ...sentryOptions
   } = opts;
-  Sentry.init(sentryOptions);
+  if (!skipInit) {
+    Sentry.init(sentryOptions);
+  }
   fastify.decorate(kSentryExtractRequestData, extractRequestData);
   fastify.decorate(kSentryExtractUserData, extractUserData);
   fastify.decorate(kSentryGetTransactionName, getTransactionName);

--- a/lib/validate.js
+++ b/lib/validate.js
@@ -7,6 +7,7 @@ module.exports = function ({
   getTransactionName,
   extractRequestData,
   extractUserData,
+  skipInit,
 } = {}) {
   if (shouldHandleError && typeof shouldHandleError !== 'function') {
     throw new TypeError('shouldHandleError should be a function.');
@@ -25,5 +26,8 @@ module.exports = function ({
   }
   if (extractUserData && typeof extractUserData !== 'function') {
     throw new TypeError('extractUserData should be a function.');
+  }
+  if (skipInit && typeof skipInit !== 'boolean') {
+    throw new TypeError('skipInit should be a boolean.');
   }
 };


### PR DESCRIPTION
Add configuration flag to skip `Sentry.init` call. Useful in environments where the call is done already before the plugin registration.

Closes #621 