### PR TITLE
fix fastify deprecation warning

### DIFF
--- a/utils.js
+++ b/utils.js
@@ -85,7 +85,7 @@ function extractUserData(request) {
 exports.extractUserData = extractUserData;
 
 const getTransactionName = (request) => {
-  return `${request.method} ${request.routerPath}`;
+  return `${request.method} ${request.routeOptions.url}`;
 };
 exports.getTransactionName = getTransactionName;
 


### PR DESCRIPTION
fixing #628  (node:20436) [FSTDEP017] FastifyDeprecation: You are accessing the deprecated "request.routerPath" property. Use "request.routeOptions.url" instead. Property "req.routerPath" will be removed in `fastify@5`.


tbh I was expecting it to be bigger :)

side note: from my understanding of process-warning used in fastify, each deprecation warning should be surfaced only once, any idea why do I see it again and again (in our test suites at least, wasn't brave enough to send it to production like this)