### PR TITLE
Update Sentry packages

### DIFF
--- a/package.json
+++ b/package.json
@@ -104,9 +104,9 @@
     "directory": "test/types"
   },
   "dependencies": {
-    "@sentry/node": "^7.60.0",
-    "@sentry/tracing": "^7.60.0",
-    "@sentry/utils": "^7.60.0",
+    "@sentry/node": "^7.105.0",
+    "@sentry/tracing": "^7.105.0",
+    "@sentry/utils": "^7.105.0",
     "cookie": "^0.6.0",
     "fastify-plugin": "^4.3.0"
   }


### PR DESCRIPTION
This updates the Sentry NPM packages from v7.60.0 to v7.105.0.

See #698 for motivation.

I've run `npm test` locally and one test is failing, but that test is failing for me on `main` as well, so I suspect it's unrelated to this change.