### PR TITLE
feat: hasTracing enabled fails sometimes returning wrong value

### DIFF
--- a/index.js
+++ b/index.js
@@ -30,7 +30,7 @@ const fastifySentry = function (fastify, opts, next) {
     return next(error);
   }
   base(fastify, config);
-  request(fastify);
+  request(fastify, config);
   next();
 };
 

--- a/lib/base.js
+++ b/lib/base.js
@@ -23,6 +23,7 @@ module.exports = function (fastify, opts) {
   if (!skipInit) {
     Sentry.init(sentryOptions);
   }
+
   fastify.decorate(kSentryExtractRequestData, extractRequestData);
   fastify.decorate(kSentryExtractUserData, extractUserData);
   fastify.decorate(kSentryGetTransactionName, getTransactionName);

--- a/lib/request.js
+++ b/lib/request.js
@@ -5,7 +5,6 @@ const {
   extractTraceparentData,
   baggageHeaderToDynamicSamplingContext,
 } = require('@sentry/utils');
-const { hasTracingEnabled } = require('@sentry/tracing');
 const { extractPathForTransaction } = require('../utils');
 const {
   kSentryRequestData,
@@ -136,8 +135,8 @@ const errorWrapperRequestHook = (fastify) => {
   };
 };
 
-module.exports = function (fastify) {
-  if (hasTracingEnabled()) {
+module.exports = function (fastify, opts) {
+  if (opts.enableTracing) {
     fastify.log.info('Sentry tracing enabled.');
     fastify.addHook('onRequest', tracingRequestHook(fastify));
     fastify.addHook('onResponse', tracingResponseHook(fastify));

--- a/tap-snapshots/test/plugin.test.js.test.cjs
+++ b/tap-snapshots/test/plugin.test.js.test.cjs
@@ -4,8 +4,10 @@
  * Re-generate by setting TAP_SNAPSHOT=1 and running tests.
  * Make sure to inspect the output below.  Do not ignore changes!
  */
-'use strict'
-exports[`test/plugin.test.js > TAP > custom extractRequestData > must match snapshot 1`] = `
+'use strict';
+exports[
+  `test/plugin.test.js > TAP > custom extractRequestData > must match snapshot 1`
+] = `
 Object {
   "breadcrumbs": undefined,
   "environment": "fastify-sentry-test",
@@ -21,9 +23,11 @@ Object {
     "ip_address": "127.0.0.1",
   },
 }
-`
+`;
 
-exports[`test/plugin.test.js > TAP > custom extractRequestData > must match snapshot 2`] = `
+exports[
+  `test/plugin.test.js > TAP > custom extractRequestData > must match snapshot 2`
+] = `
 Object {
   "breadcrumbs": undefined,
   "environment": "fastify-sentry-test",
@@ -39,9 +43,11 @@ Object {
     "ip_address": "127.0.0.1",
   },
 }
-`
+`;
 
-exports[`test/plugin.test.js > TAP > event with transactions disabled > must match snapshot 1`] = `
+exports[
+  `test/plugin.test.js > TAP > event with transactions disabled > must match snapshot 1`
+] = `
 Object {
   "cookies": Object {},
   "headers": Object {
@@ -51,9 +57,11 @@ Object {
   "method": "GET",
   "query_string": Object {},
 }
-`
+`;
 
-exports[`test/plugin.test.js > TAP > event with transactions disabled > must match snapshot 2`] = `
+exports[
+  `test/plugin.test.js > TAP > event with transactions disabled > must match snapshot 2`
+] = `
 Object {
   "breadcrumbs": undefined,
   "environment": "fastify-sentry-test",
@@ -66,9 +74,11 @@ Object {
     "username": "some",
   },
 }
-`
+`;
 
-exports[`test/plugin.test.js > TAP > event with transactions disabled > must match snapshot 3`] = `
+exports[
+  `test/plugin.test.js > TAP > event with transactions disabled > must match snapshot 3`
+] = `
 Object {
   "cookies": Object {},
   "data": "{\\"some\\":\\"some\\"}",
@@ -81,9 +91,11 @@ Object {
   "method": "POST",
   "query_string": Object {},
 }
-`
+`;
 
-exports[`test/plugin.test.js > TAP > event with transactions disabled > must match snapshot 4`] = `
+exports[
+  `test/plugin.test.js > TAP > event with transactions disabled > must match snapshot 4`
+] = `
 Object {
   "breadcrumbs": undefined,
   "environment": "fastify-sentry-test",
@@ -96,9 +108,11 @@ Object {
     "username": "some",
   },
 }
-`
+`;
 
-exports[`test/plugin.test.js > TAP > event with transactions enabled > must match snapshot 1`] = `
+exports[
+  `test/plugin.test.js > TAP > event with transactions enabled > must match snapshot 1`
+] = `
 Object {
   "cookies": Object {},
   "headers": Object {
@@ -112,9 +126,11 @@ Object {
     "username": "some",
   },
 }
-`
+`;
 
-exports[`test/plugin.test.js > TAP > event with transactions enabled > must match snapshot 2`] = `
+exports[
+  `test/plugin.test.js > TAP > event with transactions enabled > must match snapshot 2`
+] = `
 Object {
   "breadcrumbs": undefined,
   "environment": "fastify-sentry-test",
@@ -129,9 +145,11 @@ Object {
     "username": "some",
   },
 }
-`
+`;
 
-exports[`test/plugin.test.js > TAP > event with transactions enabled > must match snapshot 3`] = `
+exports[
+  `test/plugin.test.js > TAP > event with transactions enabled > must match snapshot 3`
+] = `
 Object {
   "cookies": Object {},
   "data": "{\\"some\\":\\"some\\"}",
@@ -148,9 +166,11 @@ Object {
     "username": "some",
   },
 }
-`
+`;
 
-exports[`test/plugin.test.js > TAP > event with transactions enabled > must match snapshot 4`] = `
+exports[
+  `test/plugin.test.js > TAP > event with transactions enabled > must match snapshot 4`
+] = `
 Object {
   "breadcrumbs": undefined,
   "environment": "fastify-sentry-test",
@@ -165,4 +185,4 @@ Object {
     "username": "some",
   },
 }
-`
+`;

--- a/test/plugin.test.js
+++ b/test/plugin.test.js
@@ -117,7 +117,12 @@ tap.test('event with transactions disabled', async (t) => {
 
 tap.test('event with transactions enabled', async (t) => {
   const app = await setup(
-    { dsn: DSN, environment: 'fastify-sentry-test', tracesSampleRate: 1.0 },
+    {
+      dsn: DSN,
+      environment: 'fastify-sentry-test',
+      tracesSampleRate: 1.0,
+      enableTracing: true,
+    },
     async (fastify) => {
       fastify.decorateRequest('user', null);
       fastify.addHook('onRequest', (request, reply, done) => {
@@ -224,6 +229,7 @@ tap.test('custom getTransactionName', async (t) => {
     dsn: DSN,
     environment: 'fastify-sentry-test',
     tracesSampleRate: 1.0,
+    enableTracing: true,
   });
   let response = await app.inject({
     method: 'GET',
@@ -246,6 +252,7 @@ tap.test('custom extractRequestData', async (t) => {
       dsn: DSN,
       environment: 'fastify-sentry-test',
       tracesSampleRate: 1.0,
+      enableTracing: true,
       extractRequestData: (request, keys) => {
         count++;
         t.ok(keys);


### PR DESCRIPTION
I don't know is this problem also occurs on your side, so lest discuss it here. I find that `hasTracingEnabled` is deprecated.  And on my package.json I'm having `@sentry/node` version that is more updated and deprecated the use of `hasTracingEnabled` so it always returns false! On my side, I'll just publish a fork and use it personally. 

So I created this PR as a fix, let me know if this PR necessary or not. If not, then feel free to close it. 

If you want to update the libs to newer version of sentry (basically eliminating the use of deprecated function) I can help to do that too. 

Thanks!